### PR TITLE
remove AMD support since it conflicts with client side loaders

### DIFF
--- a/lib/dust-filters-secure.js
+++ b/lib/dust-filters-secure.js
@@ -1,29 +1,13 @@
 // Copyright (c) 2013, LinkedIn Corp.
 // Released under the MIT License.
 
-/*
- * Uses CommonJS, Node, AMD or browser globals to create a module
- * per pattern of UMD
- * https://github.com/umdjs/umd/
- * */
-(function (root, factory) {
-  if (typeof exports === 'object') {
-    //CommonJS
-    factory(require('dustjs-linkedin'));
-  } else if (typeof define === 'function' && define.amd) {
-    // AMD. Register as an anonymous module.
-    define(['dustjs-linkedin'], factory);
-  } else {
-    // Browser globals (root is window)
-    factory(root.dust);
-  }
-}(this, function(dust) {
+(function(dust) {
 
   /*
    * A modules that adds secure filters to Dust
    * @module dustjs-filters-secure
    * @require dustjs-linkedin
-   * @return undefined
+   * @return {Void}
    */
   var filters = {};
 
@@ -204,5 +188,6 @@
   /* expose an unescapeHTML method */
   dust.unescapeHTML = unescapeHTML;
 
+
   /* We are writing to the `dust` object so we don't need to return anything */
-}));
+})(typeof exports === 'object' ? require('dustjs-linkedin') : dust);


### PR DESCRIPTION
see issue https://github.com/linkedin/inject/pull/240

Supporting the AMD "define" syntax works only if this file is pulled down using an AMD loader.

Including this file in a script tag (for example in a concat group) after a client-side AMD loader is implemented causes a bad situation for the anonymous module -- we would have to name the module which is arguable a bad practice.

```
/* this causes issues since dust-filters-secure tries to create an anonymous module */
<script src="amdLibrary.js"></script>
<script src="dust.js"></script>
<script src="dust-filters-secure.js"></script>
```

Let's move away from the AMD support for now so that we can continue to support including this file in the browser while an AMD loader is included.

Future work will be to create a build step to output a `dust-filters-secure-amd.js` file where our file is wrapped in a define.
